### PR TITLE
Fix the decoding of `Codable` enums

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
       run: swift test
 
   macos:
-    name: macOS Xcode
-    runs-on: macOS-latest
+    name: macOS & iOS (Xcode)
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v1
     - name: Test macOS
       run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=OS X,arch=x86_64'
     - name: Test iOS
-      run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=14.4'
+      run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=iOS Simulator,name=iPhone 13 Pro,OS=latest'

--- a/Sources/SwiftCBOR/Decoder/KeyedDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/KeyedDecodingContainer.swift
@@ -123,11 +123,12 @@ extension _CBORDecoder.KeyedContainer: KeyedDecodingContainerProtocol {
     func nestedContainer<NestedKey: CodingKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
         try checkCanDecodeValue(forKey: key)
 
-        guard let keyedContainer = self.nestedContainers[AnyCodingKey(key)] as? _CBORDecoder.KeyedContainer<NestedKey> else {
+        guard let keyedContainer = self.nestedContainers[AnyCodingKey(key)] as? _CBORDecoder.KeyedContainer<AnyCodingKey> else {
             throw DecodingError.dataCorruptedError(forKey: key, in: self, debugDescription: "cannot decode nested container for key: \(key)")
         }
 
-        return KeyedDecodingContainer(keyedContainer)
+        let container = _CBORDecoder.KeyedContainer<NestedKey>(data: keyedContainer.data, codingPath: keyedContainer.codingPath, userInfo: keyedContainer.userInfo)
+        return KeyedDecodingContainer(container)
     }
 
     func superDecoder() throws -> Decoder {

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -265,4 +265,22 @@ class CBORCodableRoundtripTests: XCTestCase {
         XCTAssertEqual(decoded.category, menuItem.category)
         XCTAssertEqual(decoded.ordinal, menuItem.ordinal)
     }
+
+
+
+    func testStructContainingEnum() {
+        enum Status: Codable {
+             case done, underway, open
+        }
+
+        struct Order: Codable {
+            var status: Status  = .done
+        }
+
+        let order = Order()
+        let cborOrder = try! CodableCBOREncoder().encode(order)
+        let decodedCBOROrder = try! CodableCBORDecoder().decode(Order.self, from: cborOrder)
+
+        XCTAssertEqual(decodedCBOROrder.status, order.status)
+    }
 }


### PR DESCRIPTION
The test that has been added as part of this PR was failing with the code currently on `master` but now passes with the rest of changes in this PR.

The fix is far from ideal because we should be able to use the container as is from `self.nestedContainers` but because when this function is called:

```swift
func nestedContainer<NestedKey: CodingKey>(
    keyedBy type: NestedKey.Type,
    forKey key: Key
) throws -> KeyedDecodingContainer<NestedKey> {
```

the `NestedKey` type is actually typed as `Order.Status.DoneCodingKeys` (i.e. the auto-generated `CodingKey`-related type for the `done` case of the `Status` enum). 

The casting of `self.nestedContainers[AnyCodingKey(key)]` to `_CBORDecoder.KeyedContainer<NestedKey>` always then fails because containers were previously inserted into `self.nestedContainers` with a key of type `AnyCodingKey`.

There might be another (better) way to solve this that involves not inserting the containers into `nestedContainers` using an `AnyCodingKey` but I've not investigated that yet.