### PR TITLE
`Codable`-related fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Test macOS
-      run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=OS X,arch=x86_64'
+      run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=macOS,arch=x86_64'
     - name: Test iOS
       run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=iOS Simulator,name=iPhone 13 Pro,OS=latest'

--- a/Sources/SwiftCBOR/AnyCodingKey.swift
+++ b/Sources/SwiftCBOR/AnyCodingKey.swift
@@ -1,37 +1,43 @@
 struct AnyCodingKey: CodingKey, Equatable {
-    var stringValue: String
+    var stringValue: String {
+        get { self._stringValue ?? "_do_not_use_this_string_value_use_the_int_value_instead_" }
+    }
+
+    var _stringValue: String?
     var intValue: Int?
 
-    init?(stringValue: String) {
-        self.stringValue = stringValue
+    init(stringValue: String) {
+        self._stringValue = stringValue
         self.intValue = nil
     }
 
-    init?(intValue: Int) {
-        self.stringValue = "\(intValue)"
+    init(intValue: Int) {
         self.intValue = intValue
+        self._stringValue = nil
     }
 
-    init<Key: CodingKey>(_ base: Key) {
-        if let intValue = base.intValue {
-            self.init(intValue: intValue)!
+    init<Key: CodingKey>(_ base: Key, useStringKey: Bool = false) {
+        if !useStringKey, let intValue = base.intValue {
+            self.init(intValue: intValue)
         } else {
-            self.init(stringValue: base.stringValue)!
+            self.init(stringValue: base.stringValue)
         }
     }
 
     func key<K: CodingKey>() -> K {
         if let intValue = self.intValue {
             return K(intValue: intValue)!
+        } else if let stringValue = self._stringValue {
+            return K(stringValue: stringValue)!
         } else {
-            return K(stringValue: self.stringValue)!
+            fatalError("AnyCodingKey created without a string or int value")
         }
     }
 }
 
 extension AnyCodingKey: Hashable {
     public func hash(into hasher: inout Hasher) {
-        self.intValue?.hash(into: &hasher) ?? self.stringValue.hash(into: &hasher)
+        self.intValue?.hash(into: &hasher) ?? self._stringValue?.hash(into: &hasher)
     }
 }
 
@@ -40,8 +46,10 @@ extension AnyCodingKey: Encodable {
         var container = encoder.singleValueContainer()
         if let intValue = self.intValue {
             try container.encode(intValue)
+        } else if let stringValue = self._stringValue {
+            try container.encode(stringValue)
         } else {
-            try container.encode(self.stringValue)
+            fatalError("AnyCodingKey created without a string or int value")
         }
     }
 }
@@ -50,10 +58,10 @@ extension AnyCodingKey: Decodable {
     init(from decoder: Decoder) throws {
         let value = try decoder.singleValueContainer()
         if let intValue = try? value.decode(Int.self) {
-            self.stringValue = "\(intValue)"
+            self._stringValue = nil
             self.intValue = intValue
         } else {
-            self.stringValue = try! value.decode(String.self)
+            self._stringValue = try! value.decode(String.self)
             self.intValue = nil
         }
     }

--- a/Sources/SwiftCBOR/CBOREncodable.swift
+++ b/Sources/SwiftCBOR/CBOREncodable.swift
@@ -3,28 +3,28 @@ import Foundation
 #endif
 
 public protocol CBOREncodable {
-    func encode() -> [UInt8]
+    func encode(options: CBOROptions) -> [UInt8]
 }
 
 extension CBOR: CBOREncodable {
     /// Encodes a wrapped CBOR value. CBOR.half (Float16) is not supported and encodes as `undefined`.
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         switch self {
         case let .unsignedInt(ui): return CBOR.encodeVarUInt(ui)
         case let .negativeInt(ni): return CBOR.encodeNegativeInt(~Int64(bitPattern: ni))
-        case let .byteString(bs): return CBOR.encodeByteString(bs)
-        case let .utf8String(str): return str.encode()
-        case let .array(a): return CBOR.encodeArray(a)
-        case let .map(m): return CBOR.encodeMap(m)
+        case let .byteString(bs): return CBOR.encodeByteString(bs, options: options)
+        case let .utf8String(str): return str.encode(options: options)
+        case let .array(a): return CBOR.encodeArray(a, options: options)
+        case let .map(m): return CBOR.encodeMap(m, options: options)
         #if canImport(Foundation)
-        case let .date(d): return CBOR.encodeDate(d)
+        case let .date(d): return CBOR.encodeDate(d, options: options)
         #endif
-        case let .tagged(t, l): return CBOR.encodeTagged(tag: t, value: l)
+        case let .tagged(t, l): return CBOR.encodeTagged(tag: t, value: l, options: options)
         case let .simple(s): return CBOR.encodeSimpleValue(s)
-        case let .boolean(b): return b.encode()
+        case let .boolean(b): return b.encode(options: options)
         case .null: return CBOR.encodeNull()
         case .undefined: return CBOR.encodeUndefined()
-        case .half(_): return CBOR.undefined.encode()
+        case .half(_): return CBOR.undefined.encode(options: options)
         case let .float(f): return f.encode()
         case let .double(d): return d.encode()
         case .break: return CBOR.encodeBreak()
@@ -33,7 +33,7 @@ extension CBOR: CBOREncodable {
 }
 
 extension Int: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         if (self < 0) {
             return CBOR.encodeNegativeInt(Int64(self))
         } else {
@@ -43,7 +43,7 @@ extension Int: CBOREncodable {
 }
 
 extension Int8: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         if (self < 0) {
             return CBOR.encodeNegativeInt(Int64(self))
         } else {
@@ -53,7 +53,7 @@ extension Int8: CBOREncodable {
 }
 
 extension Int16: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         if (self < 0) {
             return CBOR.encodeNegativeInt(Int64(self))
         } else {
@@ -63,7 +63,7 @@ extension Int16: CBOREncodable {
 }
 
 extension Int32: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         if (self < 0) {
             return CBOR.encodeNegativeInt(Int64(self))
         } else {
@@ -73,7 +73,7 @@ extension Int32: CBOREncodable {
 }
 
 extension Int64: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         if (self < 0) {
             return CBOR.encodeNegativeInt(self)
         } else {
@@ -83,96 +83,96 @@ extension Int64: CBOREncodable {
 }
 
 extension UInt: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeVarUInt(UInt64(self))
     }
 }
 
 extension UInt8: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeUInt8(self)
     }
 }
 
 
 extension UInt16: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeUInt16(self)
     }
 }
 
 extension UInt32: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeUInt32(self)
     }
 }
 
 extension UInt64: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeUInt64(self)
     }
 }
 
 extension String: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeString(self)
     }
 }
 
 extension Float: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeFloat(self)
     }
 }
 
 extension Double: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeDouble(self)
     }
 }
 
 extension Bool: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeBool(self)
     }
 }
 
 extension Array where Element: CBOREncodable {
-    public func encode() -> [UInt8] {
-        return CBOR.encodeArray(self)
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
+        return CBOR.encodeArray(self, options: options)
     }
 }
 
 extension Dictionary where Key: CBOREncodable, Value: CBOREncodable {
-    public func encode() -> [UInt8] {
-        return CBOR.encodeMap(self)
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
+        return CBOR.encodeMap(self, options: options)
     }
 }
 
 extension Optional where Wrapped: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         switch self {
-        case .some(let wrapped): return wrapped.encode()
+        case .some(let wrapped): return wrapped.encode(options: options)
         case .none: return CBOR.encodeNull()
         }
     }
 }
 
 extension NSNull: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeNull()
     }
 }
 
 #if canImport(Foundation)
 extension Date: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeDate(self)
     }
 }
 
 extension Data: CBOREncodable {
-    public func encode() -> [UInt8] {
+    public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
         return CBOR.encodeByteString(self.map{ $0 })
     }
 }

--- a/Sources/SwiftCBOR/CBOROptions.swift
+++ b/Sources/SwiftCBOR/CBOROptions.swift
@@ -1,0 +1,11 @@
+public struct CBOROptions {
+    let useStringKeys: Bool
+
+    public init(useStringKeys: Bool = false) {
+        self.useStringKeys = useStringKeys
+    }
+
+    func toEncoderOptions() -> CodableCBOREncoder._Options {
+        return CodableCBOREncoder._Options(useStringKeys: self.useStringKeys)
+    }
+}

--- a/Sources/SwiftCBOR/Decoder/CodableCBORDecoder.swift
+++ b/Sources/SwiftCBOR/Decoder/CodableCBORDecoder.swift
@@ -1,9 +1,20 @@
 import Foundation
 
-/**
-
- */
 final public class CodableCBORDecoder {
+    public var useStringKeys: Bool = false
+
+    struct _Options {
+        let useStringKeys: Bool
+
+        init(useStringKeys: Bool = false) {
+            self.useStringKeys = useStringKeys
+        }
+    }
+
+    var options: _Options {
+        return _Options(useStringKeys: self.useStringKeys)
+    }
+
     public init() {}
 
     public var userInfo: [CodingUserInfoKey : Any] = [:]
@@ -13,7 +24,7 @@ final public class CodableCBORDecoder {
     }
 
     public func decode<T: Decodable>(_ type: T.Type, from data: ArraySlice<UInt8>) throws -> T {
-        let decoder = _CBORDecoder(data: data)
+        let decoder = _CBORDecoder(data: data, options: self.options)
         decoder.userInfo = self.userInfo
         if type == Date.self {
             guard let cbor = try? CBORDecoder(input: [UInt8](data)).decodeItem(),
@@ -34,6 +45,10 @@ final public class CodableCBORDecoder {
         }
         return try T(from: decoder)
     }
+
+    func setOptions(_ newOptions: _Options) {
+        self.useStringKeys = newOptions.useStringKeys
+    }
 }
 
 final class _CBORDecoder {
@@ -44,29 +59,31 @@ final class _CBORDecoder {
     var container: CBORDecodingContainer?
     fileprivate var data: ArraySlice<UInt8>
 
-    init(data: ArraySlice<UInt8>) {
+    let options: CodableCBORDecoder._Options
+
+    init(data: ArraySlice<UInt8>, options: CodableCBORDecoder._Options) {
         self.data = data
+        self.options = options
     }
 }
 
 extension _CBORDecoder: Decoder {
     func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedDecodingContainer<Key> {
-        
-        let container = KeyedContainer<Key>(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = KeyedContainer<Key>(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
         self.container = container
 
         return KeyedDecodingContainer(container)
     }
 
     func unkeyedContainer() -> UnkeyedDecodingContainer {
-        let container = UnkeyedContainer(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = UnkeyedContainer(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
         self.container = container
 
         return container
     }
 
     func singleValueContainer() -> SingleValueDecodingContainer {
-        let container = SingleValueContainer(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = SingleValueContainer(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
         self.container = container
 
         return container
@@ -96,6 +113,20 @@ extension CBORDecodingContainer {
         defer { self.index = nextIndex }
 
         return Data(Array(self.data[self.index..<(nextIndex)]))
+    }
+
+    func peekByte() throws -> UInt8 {
+        return try peek(1).first!
+    }
+
+    func peek(_ length: Int) throws -> ArraySlice<UInt8> {
+        let nextIndex = self.index.advanced(by: length)
+        guard nextIndex <= self.data.endIndex else {
+            let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Unexpected end of data")
+            throw DecodingError.dataCorrupted(context)
+        }
+
+        return self.data[self.index..<(nextIndex)]
     }
 
     func read<T: FixedWidthInteger>(_ type: T.Type) throws -> T {

--- a/Sources/SwiftCBOR/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/SingleValueDecodingContainer.swift
@@ -6,12 +6,14 @@ extension _CBORDecoder {
         var userInfo: [CodingUserInfoKey: Any]
         var data: ArraySlice<UInt8>
         var index: Data.Index
+        let options: CodableCBORDecoder._Options
 
-        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any], options: CodableCBORDecoder._Options) {
             self.codingPath = codingPath
             self.userInfo = userInfo
             self.data = data
             self.index = self.data.startIndex
+            self.options = options
         }
 
         func checkCanDecode<T>(_ type: T.Type, format: UInt8) throws {
@@ -244,12 +246,13 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
 
     func decode<T: Decodable>(_ type: T.Type) throws -> T {
         switch type {
+        // TODO: These seem unnecessary/wrong?!
         case is Data.Type:
             return try decode(Data.self) as! T
         case is Date.Type:
             return try decode(Date.self) as! T
         default:
-            let decoder = _CBORDecoder(data: self.data)
+            let decoder = _CBORDecoder(data: self.data, options: self.options)
             let value = try T(from: decoder)
             if let nextIndex = decoder.container?.index {
                 self.index = nextIndex

--- a/Sources/SwiftCBOR/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/UnkeyedDecodingContainer.swift
@@ -5,13 +5,15 @@ extension _CBORDecoder {
         var codingPath: [CodingKey]
 
         var nestedCodingPath: [CodingKey] {
-            return self.codingPath + [AnyCodingKey(intValue: self.count ?? 0)!]
+            return self.codingPath + [AnyCodingKey(intValue: self.count ?? 0)]
         }
 
         var userInfo: [CodingUserInfoKey: Any]
 
         var data: ArraySlice<UInt8>
         var index: Data.Index
+
+        let options: CodableCBORDecoder._Options
 
         lazy var count: Int? = {
             do {
@@ -67,11 +69,12 @@ extension _CBORDecoder {
             return nestedContainers
         }()
 
-        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any], options: CodableCBORDecoder._Options) {
             self.codingPath = codingPath
             self.userInfo = userInfo
             self.data = data
             self.index = self.data.startIndex
+            self.options = options
         }
 
         var isAtEnd: Bool {
@@ -109,6 +112,7 @@ extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
 
         let container = self.nestedContainers[self.currentIndex]
         let decoder = CodableCBORDecoder()
+        decoder.setOptions(self.options)
         let value = try decoder.decode(T.self, from: container.data)
 
         return value
@@ -127,13 +131,19 @@ extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
         try checkCanDecodeValue()
         defer { self.currentIndex += 1 }
 
-        let container = self.nestedContainers[self.currentIndex] as! _CBORDecoder.KeyedContainer<NestedKey>
+        let anyCodingKeyContainer = self.nestedContainers[self.currentIndex] as! _CBORDecoder.KeyedContainer<AnyCodingKey>
 
+        let container = _CBORDecoder.KeyedContainer<NestedKey>(
+            data: anyCodingKeyContainer.data,
+            codingPath: anyCodingKeyContainer.codingPath,
+            userInfo: anyCodingKeyContainer.userInfo,
+            options: anyCodingKeyContainer.options
+        )
         return KeyedDecodingContainer(container)
     }
 
     func superDecoder() throws -> Decoder {
-        return _CBORDecoder(data: self.data)
+        return _CBORDecoder(data: self.data, options: self.options)
     }
 }
 
@@ -149,91 +159,46 @@ extension _CBORDecoder.UnkeyedContainer {
 
         switch format {
         // Integers
-        // Small positive and negative integers
-        case 0x00...0x17, 0x20...0x37:
-            length = 0
-        // UInt8 in following byte
-        case 0x18, 0x38:
-            length = 1
-        // UInt16 in following bytes
-        case 0x19, 0x39:
-            length = 2
-        // UInt32 in following bytes
-        case 0x1a, 0x3a:
-            length = 4
-        // UInt64 in following bytes
-        case 0x1b, 0x3b:
-            length = 8
+        case 0x00...0x1b, 0x20...0x3b:
+            length = try getLengthOfItem(format: format, startIndex: startIndex)
         // Byte strings
-        case 0x40...0x57:
-            length = try CBORDecoder(input: [0]).readLength(format, base: 0x40)
-        case 0x58:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 1
-        case 0x59:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 2
-        case 0x5a:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 4
-        case 0x5b:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 8
+        case 0x40...0x5b:
+            length = try getLengthOfItem(format: format, startIndex: startIndex)
         // Terminated by break
         case 0x5f:
             // TODO: Is this ever going to get hit?
             throw DecodingError.dataCorruptedError(in: self, debugDescription: "Handling byte strings with break bytes is not supported yet")
         // UTF8 strings
-        case 0x60...0x77:
-            length = try CBORDecoder(input: [0]).readLength(format, base: 0x60)
-        case 0x78:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 1
-        case 0x79:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 2
-        case 0x7a:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 4
-        case 0x7b:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
-            length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 8
+        case 0x60...0x7b:
+            length = try getLengthOfItem(format: format, startIndex: startIndex)
         // Terminated by break
         case 0x7f:
             // FIXME
             throw DecodingError.dataCorruptedError(in: self, debugDescription: "Handling UTF8 strings with break bytes is not supported yet")
         // Arrays
         case 0x80...0x9f:
-            let container = _CBORDecoder.UnkeyedContainer(data: self.data.suffix(from: startIndex), codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+            let container = _CBORDecoder.UnkeyedContainer(data: self.data.suffix(from: startIndex), codingPath: self.nestedCodingPath, userInfo: self.userInfo, options: self.options)
             _ = container.nestedContainers
 
             self.index = container.index
             return container
         // Maps
         case 0xa0...0xbf:
-            let container = _CBORDecoder.KeyedContainer<AnyCodingKey>(data: self.data.suffix(from: startIndex), codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+            let container = _CBORDecoder.KeyedContainer<AnyCodingKey>(data: self.data.suffix(from: startIndex), codingPath: self.nestedCodingPath, userInfo: self.userInfo, options: self.options)
             _ = container.nestedContainers // FIXME
 
             self.index = container.index
             return container
-        case 0xc0...0xdb:
-//            let tag = try CBORDecoder(input: [0]).readVarUInt(format, base: 0xc0)
-//            guard let item = try decodeItem() else { throw CBORError.unfinishedSequence }
-//            return CBOR.tagged(CBOR.Tag(rawValue: tag), item)
+        case 0xc0:
+            throw DecodingError.dataCorruptedError(in: self, debugDescription: "Handling text-based date/time is not supported yet")
+        // Tagged value (epoch-baed date/time)
+        case 0xc1:
+            length = try getLengthOfItem(format: try self.peekByte(), startIndex: startIndex.advanced(by: 1)) + 1
+        case 0xc2...0xdb:
             // FIXME
-            throw DecodingError.dataCorruptedError(in: self, debugDescription: "Handling tags is not supported yet")
-        case 0xe0...0xf3:
-            length = 0
-        case 0xf4, 0xf5, 0xf6, 0xf7, 0xf8:
-            length = 0
-        case 0xf9:
-            length = 2
-        case 0xfa:
-            length = 4
-        case 0xfb:
-            length = 8
-        case 0xff:
-            length = 0
+            throw DecodingError.dataCorruptedError(in: self, debugDescription: "Handling tags (other than epoch-based date/time) is not supported yet")
+        case 0xe0...0xfb, 0xff:
+            length = try getLengthOfItem(format: format, startIndex: startIndex.advanced(by: 1))
         default:
             throw DecodingError.dataCorruptedError(in: self, debugDescription: "Invalid format: \(format)")
         }
@@ -241,9 +206,75 @@ extension _CBORDecoder.UnkeyedContainer {
         let range: Range<Data.Index> = startIndex..<self.index.advanced(by: length)
         self.index = range.upperBound
 
-        let container = _CBORDecoder.SingleValueContainer(data: self.data[range.startIndex..<(range.endIndex)], codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = _CBORDecoder.SingleValueContainer(data: self.data[range.startIndex..<(range.endIndex)], codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
 
         return container
+    }
+
+    func getLengthOfItem(format: UInt8, startIndex: Data.Index) throws -> Int {
+        switch format {
+        // Integers
+        // Small positive and negative integers
+        case 0x00...0x17, 0x20...0x37:
+            return 0
+        // UInt8 in following byte
+        case 0x18, 0x38:
+            return 1
+        // UInt16 in following bytes
+        case 0x19, 0x39:
+            return 2
+        // UInt32 in following bytes
+        case 0x1a, 0x3a:
+            return 4
+        // UInt64 in following bytes
+        case 0x1b, 0x3b:
+            return 8
+        // Byte strings
+        case 0x40...0x57:
+            return try CBORDecoder(input: [0]).readLength(format, base: 0x40)
+        case 0x58:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 1
+        case 0x59:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 2
+        case 0x5a:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 4
+        case 0x5b:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 8
+        // UTF8 strings
+        case 0x60...0x77:
+            return try CBORDecoder(input: [0]).readLength(format, base: 0x60)
+        case 0x78:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 1
+        case 0x79:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 2
+        case 0x7a:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 4
+        case 0x7b:
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
+            return try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 8
+        case 0xe0...0xf3:
+            return 0
+        case 0xf4, 0xf5, 0xf6, 0xf7, 0xf8:
+            return 0
+        case 0xf9:
+            return 2
+        case 0xfa:
+            return 4
+        case 0xfb:
+            return 8
+        case 0xff:
+            return 0
+        default:
+            throw DecodingError.dataCorruptedError(in: self, debugDescription: "Invalid format for getting length of item: \(format)")
+        }
+
     }
 }
 

--- a/Sources/SwiftCBOR/Encoder/CodableCBOREncoder.swift
+++ b/Sources/SwiftCBOR/Encoder/CodableCBOREncoder.swift
@@ -27,6 +27,10 @@ public class CodableCBOREncoder {
         try value.encode(to: encoder)
         return encoder.data
     }
+
+    func setOptions(_ newOptions: _Options) {
+        self.useStringKeys = newOptions.useStringKeys
+    }
 }
 
 final class _CBOREncoder {

--- a/Sources/SwiftCBOR/Encoder/CodableCBOREncoder.swift
+++ b/Sources/SwiftCBOR/Encoder/CodableCBOREncoder.swift
@@ -1,10 +1,24 @@
 import Foundation
 
 public class CodableCBOREncoder {
+    public var useStringKeys: Bool = false
+
+    struct _Options {
+        let useStringKeys: Bool
+
+        init(useStringKeys: Bool = false) {
+            self.useStringKeys = useStringKeys
+        }
+    }
+
+    var options: _Options {
+        return _Options(useStringKeys: self.useStringKeys)
+    }
+
     public init() {}
 
     public func encode(_ value: Encodable) throws -> Data {
-        let encoder = _CBOREncoder()
+        let encoder = _CBOREncoder(options: self.options)
         if let dateVal = value as? Date {
             return Data(CBOR.encodeDate(dateVal))
         } else if let dataVal = value as? Data {
@@ -29,6 +43,12 @@ final class _CBOREncoder {
     var data: Data {
         return container?.data ?? Data()
     }
+
+    let options: CodableCBOREncoder._Options
+
+    init(options: CodableCBOREncoder._Options = CodableCBOREncoder._Options()) {
+        self.options = options
+    }
 }
 
 extension _CBOREncoder: Encoder {
@@ -39,7 +59,7 @@ extension _CBOREncoder: Encoder {
     func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
         assertCanCreateContainer()
 
-        let container = KeyedContainer<Key>(codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = KeyedContainer<Key>(codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
         self.container = container
 
         return KeyedEncodingContainer(container)
@@ -48,7 +68,7 @@ extension _CBOREncoder: Encoder {
     func unkeyedContainer() -> UnkeyedEncodingContainer {
         assertCanCreateContainer()
 
-        let container = UnkeyedContainer(codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = UnkeyedContainer(codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
         self.container = container
 
         return container
@@ -57,7 +77,7 @@ extension _CBOREncoder: Encoder {
     func singleValueContainer() -> SingleValueEncodingContainer {
         assertCanCreateContainer()
 
-        let container = SingleValueContainer(codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = SingleValueContainer(codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
         self.container = container
 
         return container

--- a/Sources/SwiftCBOR/Encoder/SingleValueEncodingContainer.swift
+++ b/Sources/SwiftCBOR/Encoder/SingleValueEncodingContainer.swift
@@ -15,9 +15,12 @@ extension _CBOREncoder {
         var codingPath: [CodingKey]
         var userInfo: [CodingUserInfoKey: Any]
 
-        init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        let options: CodableCBOREncoder._Options
+
+        init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any], options: CodableCBOREncoder._Options) {
             self.codingPath = codingPath
             self.userInfo = userInfo
+            self.options = options
         }
     }
 }
@@ -152,7 +155,7 @@ extension _CBOREncoder.SingleValueContainer: SingleValueEncodingContainer {
         case let date as Date:
             try self.encode(date)
         default:
-            let encoder = _CBOREncoder()
+            let encoder = _CBOREncoder(options: self.options)
             try value.encode(to: encoder)
             self.storage.append(encoder.data)
         }

--- a/Sources/SwiftCBOR/Encoder/UnkeyedEncodingContainer.swift
+++ b/Sources/SwiftCBOR/Encoder/UnkeyedEncodingContainer.swift
@@ -11,14 +11,17 @@ extension _CBOREncoder {
         var codingPath: [CodingKey]
 
         var nestedCodingPath: [CodingKey] {
-            return self.codingPath + [AnyCodingKey(intValue: self.count)!]
+            return self.codingPath + [AnyCodingKey(intValue: self.count)]
         }
 
         var userInfo: [CodingUserInfoKey: Any]
 
-        init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        let options: CodableCBOREncoder._Options
+
+        init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any], options: CodableCBOREncoder._Options) {
             self.codingPath = codingPath
             self.userInfo = userInfo
+            self.options = options
         }
     }
 }
@@ -35,21 +38,21 @@ extension _CBOREncoder.UnkeyedContainer: UnkeyedEncodingContainer {
     }
 
     private func nestedSingleValueContainer() -> SingleValueEncodingContainer {
-        let container = _CBOREncoder.SingleValueContainer(codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+        let container = _CBOREncoder.SingleValueContainer(codingPath: self.nestedCodingPath, userInfo: self.userInfo, options: self.options)
         self.storage.append(container)
 
         return container
     }
 
     func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
-        let container = _CBOREncoder.KeyedContainer<NestedKey>(codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+        let container = _CBOREncoder.KeyedContainer<NestedKey>(codingPath: self.nestedCodingPath, userInfo: self.userInfo, options: self.options)
         self.storage.append(container)
 
         return KeyedEncodingContainer(container)
     }
 
     func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        let container = _CBOREncoder.UnkeyedContainer(codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+        let container = _CBOREncoder.UnkeyedContainer(codingPath: self.nestedCodingPath, userInfo: self.userInfo, options: self.options)
         self.storage.append(container)
 
         return container

--- a/SwiftCBOR.xcodeproj/project.pbxproj
+++ b/SwiftCBOR.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
             "en"
          );
          mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_39";
+         productRefGroup = "OBJ_40";
          projectDirPath = ".";
          targets = (
             "SwiftCBOR::SwiftCBOR",
@@ -37,9 +37,10 @@
             "OBJ_16",
             "OBJ_17",
             "OBJ_18",
-            "OBJ_23",
-            "OBJ_28",
-            "OBJ_29"
+            "OBJ_19",
+            "OBJ_24",
+            "OBJ_29",
+            "OBJ_30"
          );
          name = "SwiftCBOR";
          path = "Sources/SwiftCBOR";
@@ -81,20 +82,20 @@
          sourceTree = "<group>";
       };
       "OBJ_18" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_19",
-            "OBJ_20",
-            "OBJ_21",
-            "OBJ_22"
-         );
-         name = "Decoder";
-         path = "Decoder";
+         isa = "PBXFileReference";
+         path = "CBOROptions.swift";
          sourceTree = "<group>";
       };
       "OBJ_19" = {
-         isa = "PBXFileReference";
-         path = "CodableCBORDecoder.swift";
+         isa = "PBXGroup";
+         children = (
+            "OBJ_20",
+            "OBJ_21",
+            "OBJ_22",
+            "OBJ_23"
+         );
+         name = "Decoder";
+         path = "Decoder";
          sourceTree = "<group>";
       };
       "OBJ_2" = {
@@ -108,59 +109,59 @@
       };
       "OBJ_20" = {
          isa = "PBXFileReference";
-         path = "KeyedDecodingContainer.swift";
+         path = "CodableCBORDecoder.swift";
          sourceTree = "<group>";
       };
       "OBJ_21" = {
          isa = "PBXFileReference";
-         path = "SingleValueDecodingContainer.swift";
+         path = "KeyedDecodingContainer.swift";
          sourceTree = "<group>";
       };
       "OBJ_22" = {
          isa = "PBXFileReference";
-         path = "UnkeyedDecodingContainer.swift";
+         path = "SingleValueDecodingContainer.swift";
          sourceTree = "<group>";
       };
       "OBJ_23" = {
+         isa = "PBXFileReference";
+         path = "UnkeyedDecodingContainer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_24" = {
          isa = "PBXGroup";
          children = (
-            "OBJ_24",
             "OBJ_25",
             "OBJ_26",
-            "OBJ_27"
+            "OBJ_27",
+            "OBJ_28"
          );
          name = "Encoder";
          path = "Encoder";
          sourceTree = "<group>";
       };
-      "OBJ_24" = {
+      "OBJ_25" = {
          isa = "PBXFileReference";
          path = "CodableCBOREncoder.swift";
          sourceTree = "<group>";
       };
-      "OBJ_25" = {
+      "OBJ_26" = {
          isa = "PBXFileReference";
          path = "KeyedEncodingContainer.swift";
          sourceTree = "<group>";
       };
-      "OBJ_26" = {
+      "OBJ_27" = {
          isa = "PBXFileReference";
          path = "SingleValueEncodingContainer.swift";
          sourceTree = "<group>";
       };
-      "OBJ_27" = {
+      "OBJ_28" = {
          isa = "PBXFileReference";
          path = "UnkeyedEncodingContainer.swift";
          sourceTree = "<group>";
       };
-      "OBJ_28" = {
-         isa = "PBXFileReference";
-         path = "FixedWidthInteger+Bytes.swift";
-         sourceTree = "<group>";
-      };
       "OBJ_29" = {
          isa = "PBXFileReference";
-         path = "Util.swift";
+         path = "FixedWidthInteger+Bytes.swift";
          sourceTree = "<group>";
       };
       "OBJ_3" = {
@@ -201,73 +202,68 @@
          name = "Debug";
       };
       "OBJ_30" = {
+         isa = "PBXFileReference";
+         path = "Util.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_31" = {
          isa = "PBXGroup";
          children = (
-            "OBJ_31"
+            "OBJ_32"
          );
          name = "Tests";
          path = "";
          sourceTree = "SOURCE_ROOT";
       };
-      "OBJ_31" = {
+      "OBJ_32" = {
          isa = "PBXGroup";
          children = (
-            "OBJ_32",
             "OBJ_33",
             "OBJ_34",
             "OBJ_35",
             "OBJ_36",
             "OBJ_37",
-            "OBJ_38"
+            "OBJ_38",
+            "OBJ_39"
          );
          name = "SwiftCBORTests";
          path = "Tests/SwiftCBORTests";
          sourceTree = "SOURCE_ROOT";
       };
-      "OBJ_32" = {
+      "OBJ_33" = {
          isa = "PBXFileReference";
          path = "Info.plist";
          sourceTree = "<group>";
       };
-      "OBJ_33" = {
+      "OBJ_34" = {
          isa = "PBXFileReference";
          path = "CBORCodableRoundtripTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_34" = {
+      "OBJ_35" = {
          isa = "PBXFileReference";
          path = "CBORDecoderTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_35" = {
+      "OBJ_36" = {
          isa = "PBXFileReference";
          path = "CBOREncoderTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_36" = {
+      "OBJ_37" = {
          isa = "PBXFileReference";
          path = "CBORTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_37" = {
+      "OBJ_38" = {
          isa = "PBXFileReference";
          path = "CodableCBORDecoderTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_38" = {
+      "OBJ_39" = {
          isa = "PBXFileReference";
          path = "CodableCBOREncoderTests.swift";
          sourceTree = "<group>";
-      };
-      "OBJ_39" = {
-         isa = "PBXGroup";
-         children = (
-            "SwiftCBOR::SwiftCBOR::Product",
-            "SwiftCBOR::SwiftCBORTests::Product"
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
       };
       "OBJ_4" = {
          isa = "XCBuildConfiguration";
@@ -302,45 +298,73 @@
          };
          name = "Release";
       };
-      "OBJ_42" = {
+      "OBJ_40" = {
+         isa = "PBXGroup";
+         children = (
+            "SwiftCBOR::SwiftCBOR::Product",
+            "SwiftCBOR::SwiftCBORTests::Product"
+         );
+         name = "Products";
+         path = "";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "OBJ_43" = {
          isa = "PBXFileReference";
          path = "CODE_OF_CONDUCT.md";
          sourceTree = "<group>";
       };
-      "OBJ_43" = {
+      "OBJ_44" = {
          isa = "PBXFileReference";
          path = "Package.xcconfig";
          sourceTree = "<group>";
       };
-      "OBJ_44" = {
+      "OBJ_45" = {
          isa = "PBXFileReference";
          path = "SwiftCBOR.podspec";
          sourceTree = "<group>";
       };
-      "OBJ_45" = {
+      "OBJ_46" = {
          isa = "PBXFileReference";
          path = "README.md";
          sourceTree = "<group>";
       };
-      "OBJ_46" = {
+      "OBJ_47" = {
          isa = "PBXFileReference";
          path = "UNLICENSE";
          sourceTree = "<group>";
       };
-      "OBJ_48" = {
+      "OBJ_49" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_49",
-            "OBJ_50"
+            "OBJ_50",
+            "OBJ_51"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_49" = {
+      "OBJ_5" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_6",
+            "OBJ_7",
+            "OBJ_9",
+            "OBJ_31",
+            "OBJ_40",
+            "OBJ_43",
+            "OBJ_44",
+            "OBJ_45",
+            "OBJ_46",
+            "OBJ_47"
+         );
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_50" = {
          isa = "XCBuildConfiguration";
          baseConfigurationReference = "OBJ_8";
          buildSettings = {
             CURRENT_PROJECT_VERSION = "1";
+            DRIVERKIT_DEPLOYMENT_TARGET = "19.0";
             ENABLE_TESTABILITY = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",
@@ -379,28 +403,12 @@
          };
          name = "Debug";
       };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_9",
-            "OBJ_30",
-            "OBJ_39",
-            "OBJ_42",
-            "OBJ_43",
-            "OBJ_44",
-            "OBJ_45",
-            "OBJ_46"
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_50" = {
+      "OBJ_51" = {
          isa = "XCBuildConfiguration";
          baseConfigurationReference = "OBJ_8";
          buildSettings = {
             CURRENT_PROJECT_VERSION = "1";
+            DRIVERKIT_DEPLOYMENT_TARGET = "19.0";
             ENABLE_TESTABILITY = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",
@@ -439,10 +447,9 @@
          };
          name = "Release";
       };
-      "OBJ_51" = {
+      "OBJ_52" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_52",
             "OBJ_53",
             "OBJ_54",
             "OBJ_55",
@@ -457,40 +464,38 @@
             "OBJ_64",
             "OBJ_65",
             "OBJ_66",
-            "OBJ_67"
+            "OBJ_67",
+            "OBJ_68",
+            "OBJ_69"
          );
-      };
-      "OBJ_52" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
       };
       "OBJ_53" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
+         fileRef = "OBJ_12";
       };
       "OBJ_54" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
+         fileRef = "OBJ_13";
       };
       "OBJ_55" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
+         fileRef = "OBJ_14";
       };
       "OBJ_56" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
+         fileRef = "OBJ_15";
       };
       "OBJ_57" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
+         fileRef = "OBJ_16";
       };
       "OBJ_58" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
+         fileRef = "OBJ_17";
       };
       "OBJ_59" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
+         fileRef = "OBJ_18";
       };
       "OBJ_6" = {
          isa = "PBXFileReference";
@@ -500,40 +505,43 @@
       };
       "OBJ_60" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
+         fileRef = "OBJ_20";
       };
       "OBJ_61" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
+         fileRef = "OBJ_21";
       };
       "OBJ_62" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
+         fileRef = "OBJ_22";
       };
       "OBJ_63" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
+         fileRef = "OBJ_23";
       };
       "OBJ_64" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
+         fileRef = "OBJ_25";
       };
       "OBJ_65" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_27";
+         fileRef = "OBJ_26";
       };
       "OBJ_66" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
+         fileRef = "OBJ_27";
       };
       "OBJ_67" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_29";
+         fileRef = "OBJ_28";
       };
       "OBJ_68" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_29";
+      };
+      "OBJ_69" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_30";
       };
       "OBJ_7" = {
          isa = "PBXGroup";
@@ -545,15 +553,20 @@
          sourceTree = "<group>";
       };
       "OBJ_70" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_72" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_71",
-            "OBJ_72"
+            "OBJ_73",
+            "OBJ_74"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_71" = {
+      "OBJ_73" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             LD = "/usr/bin/true";
@@ -561,7 +574,7 @@
                "-swift-version",
                "5",
                "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI",
                "-sdk",
                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk",
                "-package-description-version",
@@ -571,7 +584,7 @@
          };
          name = "Debug";
       };
-      "OBJ_72" = {
+      "OBJ_74" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             LD = "/usr/bin/true";
@@ -579,7 +592,7 @@
                "-swift-version",
                "5",
                "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI",
                "-sdk",
                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk",
                "-package-description-version",
@@ -589,61 +602,62 @@
          };
          name = "Release";
       };
-      "OBJ_73" = {
+      "OBJ_75" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_74"
+            "OBJ_76"
          );
       };
-      "OBJ_74" = {
+      "OBJ_76" = {
          isa = "PBXBuildFile";
          fileRef = "OBJ_6";
       };
-      "OBJ_76" = {
+      "OBJ_78" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_77",
-            "OBJ_78"
+            "OBJ_79",
+            "OBJ_80"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_77" = {
+      "OBJ_79" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
          };
          name = "Debug";
-      };
-      "OBJ_78" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_79" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftCBOR::SwiftCBORTests";
       };
       "OBJ_8" = {
          isa = "PBXFileReference";
          path = "Package.xcconfig";
          sourceTree = "<group>";
       };
+      "OBJ_80" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Release";
+      };
       "OBJ_81" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftCBOR::SwiftCBORTests";
+      };
+      "OBJ_83" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_82",
-            "OBJ_83"
+            "OBJ_84",
+            "OBJ_85"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_82" = {
+      "OBJ_84" = {
          isa = "XCBuildConfiguration";
          baseConfigurationReference = "OBJ_8";
          buildSettings = {
             CLANG_ENABLE_MODULES = "YES";
             CURRENT_PROJECT_VERSION = "1";
+            DRIVERKIT_DEPLOYMENT_TARGET = "19.0";
             EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",
@@ -679,12 +693,13 @@
          };
          name = "Debug";
       };
-      "OBJ_83" = {
+      "OBJ_85" = {
          isa = "XCBuildConfiguration";
          baseConfigurationReference = "OBJ_8";
          buildSettings = {
             CLANG_ENABLE_MODULES = "YES";
             CURRENT_PROJECT_VERSION = "1";
+            DRIVERKIT_DEPLOYMENT_TARGET = "19.0";
             EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",
@@ -720,36 +735,28 @@
          };
          name = "Release";
       };
-      "OBJ_84" = {
+      "OBJ_86" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_85",
-            "OBJ_86",
             "OBJ_87",
             "OBJ_88",
             "OBJ_89",
-            "OBJ_90"
+            "OBJ_90",
+            "OBJ_91",
+            "OBJ_92"
          );
-      };
-      "OBJ_85" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_33";
-      };
-      "OBJ_86" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_34";
       };
       "OBJ_87" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_35";
+         fileRef = "OBJ_34";
       };
       "OBJ_88" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_36";
+         fileRef = "OBJ_35";
       };
       "OBJ_89" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_37";
+         fileRef = "OBJ_36";
       };
       "OBJ_9" = {
          isa = "PBXGroup";
@@ -762,28 +769,36 @@
       };
       "OBJ_90" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_38";
+         fileRef = "OBJ_37";
       };
       "OBJ_91" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_92"
-         );
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_38";
       };
       "OBJ_92" = {
          isa = "PBXBuildFile";
-         fileRef = "SwiftCBOR::SwiftCBOR::Product";
+         fileRef = "OBJ_39";
       };
       "OBJ_93" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_94"
+         );
+      };
+      "OBJ_94" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftCBOR::SwiftCBOR::Product";
+      };
+      "OBJ_95" = {
          isa = "PBXTargetDependency";
          target = "SwiftCBOR::SwiftCBOR";
       };
       "SwiftCBOR::SwiftCBOR" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_48";
+         buildConfigurationList = "OBJ_49";
          buildPhases = (
-            "OBJ_51",
-            "OBJ_68"
+            "OBJ_52",
+            "OBJ_70"
          );
          dependencies = (
          );
@@ -799,24 +814,24 @@
       };
       "SwiftCBOR::SwiftCBORPackageTests::ProductTarget" = {
          isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_76";
+         buildConfigurationList = "OBJ_78";
          buildPhases = (
          );
          dependencies = (
-            "OBJ_79"
+            "OBJ_81"
          );
          name = "SwiftCBORPackageTests";
          productName = "SwiftCBORPackageTests";
       };
       "SwiftCBOR::SwiftCBORTests" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_81";
+         buildConfigurationList = "OBJ_83";
          buildPhases = (
-            "OBJ_84",
-            "OBJ_91"
+            "OBJ_86",
+            "OBJ_93"
          );
          dependencies = (
-            "OBJ_93"
+            "OBJ_95"
          );
          name = "SwiftCBORTests";
          productName = "SwiftCBORTests";
@@ -830,9 +845,9 @@
       };
       "SwiftCBOR::SwiftPMPackageDescription" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_70";
+         buildConfigurationList = "OBJ_72";
          buildPhases = (
-            "OBJ_73"
+            "OBJ_75"
          );
          dependencies = (
          );

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -15,7 +15,9 @@ class CBORCodableRoundtripTests: XCTestCase {
         ("testArrays", testArrays),
         ("testMaps", testMaps),
         ("testWrappedStruct", testWrappedStruct),
+        ("testStructWithFloat", testStructWithFloat),
         ("testStructContainingEnum", testStructContainingEnum)
+        ("testFoundationHeavyType", testFoundationHeavyType)
     ]
 
     struct MyStruct: Codable, Equatable, Hashable {

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -16,7 +16,7 @@ class CBORCodableRoundtripTests: XCTestCase {
         ("testMaps", testMaps),
         ("testWrappedStruct", testWrappedStruct),
         ("testStructWithFloat", testStructWithFloat),
-        ("testStructContainingEnum", testStructContainingEnum)
+        ("testStructContainingEnum", testStructContainingEnum),
         ("testFoundationHeavyType", testFoundationHeavyType)
     ]
 

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -301,12 +301,9 @@ class CBORCodableRoundtripTests: XCTestCase {
             let decimal: Decimal
             let dateInterval: DateInterval
             let characterSet: CharacterSet
-            let affineTransform: AffineTransform
             let indexPath: IndexPath
             let indexSet: IndexSet
             let range: Range<Int>
-            let point: NSPoint
-            let size: NSSize
             let data: Data
         }
 
@@ -353,12 +350,9 @@ class CBORCodableRoundtripTests: XCTestCase {
             decimal: Decimal(sign: .plus, exponent: -10, significand: 31415926536),
             dateInterval: DateInterval(start: Date(timeIntervalSince1970: 1501283772), duration: 86400),
             characterSet: CharacterSet.illegalCharacters,
-            affineTransform: AffineTransform(translationByX: 12.34, byY: -56.78),
-            indexPath: IndexPath(item: 12, section: 3),
+            indexPath: IndexPath(indexes: [12, 3]),
             indexSet: IndexSet(arrayLiteral: 1, 2, 3, 9, 123, 1247890123),
             range: Range(NSRange(location: 12, length: 366))!,
-            point: NSPoint(x: -99.123, y: 2.04),
-            size: NSSize(width: 77.77, height: 88.88),
             data: Data([163, 99, 95, 105, 100, 99, 97, 97, 97, 104, 99, 97, 116, 101, 103, 111, 114, 121, 100, 99, 97, 107, 101, 103, 111, 114, 100, 105, 110, 97, 108, 250, 65, 64, 0, 0])
         )
 
@@ -374,4 +368,32 @@ class CBORCodableRoundtripTests: XCTestCase {
         let decoded = try! CodableCBORDecoder().decode(FoundationLaden.self, from: encoded)
         XCTAssertEqual(decoded, foundationLadenObj)
     }
+
+#if os(macOS)
+    func testMacOSOnlyTypes() {
+        struct MacOSOnlyTypes: Codable, Equatable {
+            let affineTransform: AffineTransform
+            let point: NSPoint
+            let size: NSSize
+        }
+
+        let macOSOnlyObj = MacOSOnlyTypes(
+            affineTransform: AffineTransform(translationByX: 12.34, byY: -56.78),
+            point: NSPoint(x: -99.123, y: 2.04),
+            size: NSSize(width: 77.77, height: 88.88)
+        )
+
+        let encoder = CodableCBOREncoder()
+        encoder.useStringKeys = true
+        let encodedWithStringKeys = try! encoder.encode(macOSOnlyObj)
+        let decoder = CodableCBORDecoder()
+        decoder.useStringKeys = true
+        let decodedFromStringKeys = try! decoder.decode(MacOSOnlyTypes.self, from: encodedWithStringKeys)
+        XCTAssertEqual(decodedFromStringKeys, macOSOnlyObj)
+
+        let encoded = try! CodableCBOREncoder().encode(macOSOnlyObj)
+        let decoded = try! CodableCBORDecoder().decode(MacOSOnlyTypes.self, from: encoded)
+        XCTAssertEqual(decoded, macOSOnlyObj)
+    }
+#endif
 }

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import SwiftCBOR
 
 class CBORCodableRoundtripTests: XCTestCase {

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -15,6 +15,7 @@ class CBORCodableRoundtripTests: XCTestCase {
         ("testArrays", testArrays),
         ("testMaps", testMaps),
         ("testWrappedStruct", testWrappedStruct),
+        ("testStructContainingEnum", testStructContainingEnum)
     ]
 
     struct MyStruct: Codable, Equatable, Hashable {
@@ -266,8 +267,6 @@ class CBORCodableRoundtripTests: XCTestCase {
         XCTAssertEqual(decoded.ordinal, menuItem.ordinal)
     }
 
-
-
     func testStructContainingEnum() {
         enum Status: Codable {
              case done, underway, open
@@ -282,5 +281,94 @@ class CBORCodableRoundtripTests: XCTestCase {
         let decodedCBOROrder = try! CodableCBORDecoder().decode(Order.self, from: cborOrder)
 
         XCTAssertEqual(decodedCBOROrder.status, order.status)
+    }
+
+    func testFoundationHeavyType() {
+        struct FoundationLaden: Codable, Equatable {
+            let date: Date
+            let dateComponents: DateComponents
+            let calendar: Calendar
+            let locale: Locale
+            let url: URL
+            let urlComponents: URLComponents
+            let measurement: Measurement<UnitMass>
+            let uuid: UUID
+            let personNameComponents: PersonNameComponents
+            let timeZone: TimeZone
+            let decimal: Decimal
+            let dateInterval: DateInterval
+            let characterSet: CharacterSet
+            let affineTransform: AffineTransform
+            let indexPath: IndexPath
+            let indexSet: IndexSet
+            let range: Range<Int>
+            let point: NSPoint
+            let size: NSSize
+            let data: Data
+        }
+
+        var personNameComponents = PersonNameComponents()
+        personNameComponents.givenName = "Bridget"
+        personNameComponents.familyName = "Christie"
+        personNameComponents.middleName = "Louise"
+        personNameComponents.namePrefix = "Dame"
+        personNameComponents.nickname = "Bridge"
+        personNameComponents.nameSuffix = "Esq."
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let dateComponents: Set<Calendar.Component> = [
+            .era,
+            .year,
+            .month,
+            .day,
+            .hour,
+            .minute,
+            .second,
+            .weekday,
+            .weekdayOrdinal,
+            .weekOfMonth,
+            .weekOfYear,
+            .yearForWeekOfYear,
+            .timeZone,
+            .calendar,
+            .nanosecond,
+            .quarter,
+        ]
+
+        let foundationLadenObj = FoundationLaden(
+            date: Date(timeIntervalSince1970: 1501283774),
+            dateComponents: calendar.dateComponents(dateComponents, from: Date(timeIntervalSince1970: 1501283775)),
+            calendar: calendar,
+            locale: Locale(identifier: "UTC"),
+            url: URL(string: "https://www.cars.com/cool/big?color=yellow")!,
+            urlComponents: URLComponents(string: "https://subdomain.domain.com/some/path?and_a_query=string")!,
+            measurement: Measurement(value: 67.4, unit: UnitMass.grams),
+            uuid: UUID(),
+            personNameComponents: personNameComponents,
+            timeZone: TimeZone(identifier: "PST")!,
+            decimal: Decimal(sign: .plus, exponent: -10, significand: 31415926536),
+            dateInterval: DateInterval(start: Date(timeIntervalSince1970: 1501283772), duration: 86400),
+            characterSet: CharacterSet.illegalCharacters,
+            affineTransform: AffineTransform(translationByX: 12.34, byY: -56.78),
+            indexPath: IndexPath(item: 12, section: 3),
+            indexSet: IndexSet(arrayLiteral: 1, 2, 3, 9, 123, 1247890123),
+            range: Range(NSRange(location: 12, length: 366))!,
+            point: NSPoint(x: -99.123, y: 2.04),
+            size: NSSize(width: 77.77, height: 88.88),
+            data: Data([163, 99, 95, 105, 100, 99, 97, 97, 97, 104, 99, 97, 116, 101, 103, 111, 114, 121, 100, 99, 97, 107, 101, 103, 111, 114, 100, 105, 110, 97, 108, 250, 65, 64, 0, 0])
+        )
+
+        let encoder = CodableCBOREncoder()
+        encoder.useStringKeys = true
+        let encodedWithStringKeys = try! encoder.encode(foundationLadenObj)
+        let decoder = CodableCBORDecoder()
+        decoder.useStringKeys = true
+        let decodedFromStringKeys = try! decoder.decode(FoundationLaden.self, from: encodedWithStringKeys)
+        XCTAssertEqual(decodedFromStringKeys, foundationLadenObj)
+
+        let encoded = try! CodableCBOREncoder().encode(foundationLadenObj)
+        let decoded = try! CodableCBORDecoder().decode(FoundationLaden.self, from: encoded)
+        XCTAssertEqual(decoded, foundationLadenObj)
     }
 }

--- a/Tests/SwiftCBORTests/CBOREncoderTests.swift
+++ b/Tests/SwiftCBORTests/CBOREncoderTests.swift
@@ -21,9 +21,9 @@ class CBOREncoderTests: XCTestCase {
         ("testEncodeAny", testEncodeAny),
     ]
 
-    func assertEquivalent<T: CBOREncodable>(_ input: T, _ cbor: [UInt8]) {
-        XCTAssertEqual(input.encode(), cbor)
-        XCTAssertEqual(try! CBOR.decode(input.encode()), try! CBOR.decode(cbor))
+    func assertEquivalent<T: CBOREncodable>(_ input: T, _ cbor: [UInt8], options: CBOROptions = CBOROptions()) {
+        XCTAssertEqual(input.encode(options: options), cbor)
+        XCTAssertEqual(try! CBOR.decode(input.encode(options: options)), try! CBOR.decode(cbor))
     }
 
     func testEncodeInts() {
@@ -242,12 +242,12 @@ class CBOREncoderTests: XCTestCase {
             var x: Int
             var y: String
 
-            public func encode() -> [UInt8] {
-                let cborWrapper : CBOR = [
+            public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
+                let cborWrapper: CBOR = [
                     "x": CBOR(integerLiteral: self.x),
                     "y": .utf8String(self.y)
                 ]
-                return cborWrapper.encode()
+                return cborWrapper.encode(options: options)
             }
         }
 


### PR DESCRIPTION
Fixes `CodableCBORDecoder` decoding of lots of different types, particularly ones that get encoded to unkeyed or keyed containers, as well as `Date`s that were getting encoded as a tagged value but were not being handled in the decode path.

Also introduces `CBOROptions` (and other related `Options`-based types) to allow users to specify options relating to how they want the CBOR to be encoded. This is currently only really relevant when dealing with `Codable`-conforming types that have `CodingKeys` that can be encoded as strings or integers. Lots of types in `Foundation` happen to such types. For some use cases it can be desirable to be able to control whether the keys in these maps get encoded as strings or integers. 