### PR TITLE
Add an option to forbid non-String map keys.

### DIFF
--- a/Sources/SwiftCBOR/CBOROptions.swift
+++ b/Sources/SwiftCBOR/CBOROptions.swift
@@ -1,16 +1,23 @@
 public struct CBOROptions {
     let useStringKeys: Bool
     let dateStrategy: DateStrategy
+    let forbidNonStringMapKeys: Bool
 
-    public init(useStringKeys: Bool = false, dateStrategy: DateStrategy = .taggedAsEpochTimestamp) {
+    public init(
+        useStringKeys: Bool = false,
+        dateStrategy: DateStrategy = .taggedAsEpochTimestamp,
+        forbidNonStringMapKeys: Bool = false
+    ) {
         self.useStringKeys = useStringKeys
         self.dateStrategy = dateStrategy
+        self.forbidNonStringMapKeys = forbidNonStringMapKeys
     }
 
     func toCodableEncoderOptions() -> CodableCBOREncoder._Options {
         return CodableCBOREncoder._Options(
             useStringKeys: self.useStringKeys,
-            dateStrategy: self.dateStrategy
+            dateStrategy: self.dateStrategy,
+            forbidNonStringMapKeys: self.forbidNonStringMapKeys
         )
     }
 
@@ -32,3 +39,7 @@ struct AnnotatedMapDateStrategy {
     static let typeValue = "date_epoch_timestamp"
     static let valueKey = "__value"
 }
+
+protocol SwiftCBORStringKey {}
+
+extension String: SwiftCBORStringKey {}

--- a/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
+++ b/Tests/SwiftCBORTests/CBORCodableRoundtripTests.swift
@@ -194,9 +194,16 @@ class CBORCodableRoundtripTests: XCTestCase {
         let stringToString = try! CodableCBOREncoder().encode(["a": "A", "b": "B", "c": "C", "d": "D", "e": "E"])
         let stringToStringDecoded = try! CodableCBORDecoder().decode([String: String].self, from: stringToString)
         XCTAssertEqual(stringToStringDecoded, ["a": "A", "b": "B", "c": "C", "d": "D", "e": "E"])
-        let oneTwoThreeFour = try! CodableCBOREncoder().encode([1: 2, 3: 4])
+        let intKeyedMap = [1: 2, 3: 4]
+        let oneTwoThreeFour = try! CodableCBOREncoder().encode(intKeyedMap)
         let oneTwoThreeFourDecoded = try! CodableCBORDecoder().decode([Int: Int].self, from: oneTwoThreeFour)
-        XCTAssertEqual(oneTwoThreeFourDecoded, [1: 2, 3: 4])
+        XCTAssertEqual(oneTwoThreeFourDecoded, intKeyedMap)
+
+        let encoder = CodableCBOREncoder()
+        encoder.forbidNonStringMapKeys = true
+        XCTAssertThrowsError(try encoder.encode(intKeyedMap)) { err in
+            XCTAssertEqual(err as! CBOREncoderError, CBOREncoderError.nonStringKeyInMap)
+        }
     }
 
     func testWrappedStruct() {

--- a/Tests/SwiftCBORTests/CBOREncoderTests.swift
+++ b/Tests/SwiftCBORTests/CBOREncoderTests.swift
@@ -122,6 +122,14 @@ class CBOREncoderTests: XCTestCase {
         ]
         let encodedMapToAny = try! CBOR.encodeMap(mapToAny)
         XCTAssertEqual(encodedMapToAny, [0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03])
+
+        let mapToAnyWithIntKeys: [Int: Any] = [
+            12: 1,
+            51: "testing"
+        ]
+        XCTAssertThrowsError(try CBOR.encodeMap(mapToAnyWithIntKeys, options: CBOROptions(forbidNonStringMapKeys: true))) { err in
+            XCTAssertEqual(err as! CBOREncoderError, CBOREncoderError.nonStringKeyInMap)
+        }
     }
 
     func testEncodeTagged() {


### PR DESCRIPTION
The current encoding APIs are generally non-throwing and so in a lot of places
we'd end up with a change to a throwing API if the various `encodeMap`
implementations were turned into throwing functions (some of them already are
though).

For now I've decided to leave this as are and use a `try!` in the cases where
the current `encodeMap` implementation is non-throwing. This will therefore lead
to runtime errors but I think this is fine for now given that the option to
forbid non-String map keys is opt-in.

It might be useful in the future to either change most/all of the
`encode`-relevant functions to be throwing. Either that or perhaps there could
be throwing versions to live alongside the non-throwing versions that currently
exist.