### PR TITLE
Fixes for: empty optional array, trying to decode mismatched types doesn't error, and `Codable` decoding of indefinites maps/arrays

### DIFF
--- a/Sources/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/Decoder/SingleValueDecodingContainer.swift
@@ -50,7 +50,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .boolean(let bool): return bool
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Bool.self, context)
         }
     }
 
@@ -63,7 +63,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .utf8String(let str): return str
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(String.self, context)
         }
     }
 
@@ -92,7 +92,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .half(let flt): return Float(flt)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Float.self, context)
         }
     }
 
@@ -106,7 +106,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .negativeInt(let u64): return -1 - Int(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Int.self, context)
         }
     }
 
@@ -120,7 +120,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .negativeInt(let u64): return -1 - Int8(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Int8.self, context)
         }
     }
 
@@ -134,7 +134,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .negativeInt(let u64): return -1 - Int16(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Int16.self, context)
         }
     }
 
@@ -148,7 +148,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .negativeInt(let u64): return -1 - Int32(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Int32.self, context)
         }
     }
 
@@ -162,7 +162,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .negativeInt(let u64): return -1 - Int64(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Int64.self, context)
         }
     }
 
@@ -175,7 +175,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .unsignedInt(let u64): return UInt(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(UInt.self, context)
         }
     }
 
@@ -188,7 +188,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .unsignedInt(let u64): return UInt8(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(UInt8.self, context)
         }
     }
 
@@ -201,7 +201,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .unsignedInt(let u64): return UInt16(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(UInt16.self, context)
         }
     }
 
@@ -214,7 +214,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .unsignedInt(let u64): return UInt32(u64)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(UInt32.self, context)
         }
     }
 
@@ -227,7 +227,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .unsignedInt(let u64): return u64
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(UInt64.self, context)
         }
     }
 
@@ -240,7 +240,7 @@ extension _CBORDecoder.SingleValueContainer: SingleValueDecodingContainer {
         case .byteString(let bytes): return Data(bytes)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(self.data)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Data.self, context)
         }
     }
 

--- a/Sources/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/Decoder/UnkeyedDecodingContainer.swift
@@ -102,7 +102,7 @@ extension _CBORDecoder {
 }
 
 extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
-   
+
     func decodeNil() throws -> Bool {
         if self.isEmpty {
             return false
@@ -195,7 +195,7 @@ extension _CBORDecoder.UnkeyedContainer {
         // Maps
         case 0xa0...0xbf:
             let container = _CBORDecoder.KeyedContainer<AnyCodingKey>(data: self.data.suffix(from: startIndex), codingPath: self.nestedCodingPath, userInfo: self.userInfo, options: self.options)
-            _ = container.nestedContainers // FIXME
+            let _ = try container.nestedContainers() // FIXME
 
             self.index = container.index
             return container

--- a/Sources/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/Decoder/UnkeyedDecodingContainer.swift
@@ -85,6 +85,13 @@ extension _CBORDecoder {
             return currentIndex >= count
         }
 
+        var isEmpty: Bool {
+            if let count = self.count, count == 0 {
+                return true
+            }
+            return false
+        }
+
         func checkCanDecodeValue() throws {
             guard !self.isAtEnd else {
                 throw DecodingError.dataCorruptedError(in: self, debugDescription: "Unexpected end of data")
@@ -97,6 +104,9 @@ extension _CBORDecoder {
 extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
    
     func decodeNil() throws -> Bool {
+        if self.isEmpty {
+            return false
+        }
         try checkCanDecodeValue()
         defer { self.currentIndex += 1 }
 

--- a/Sources/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/Decoder/UnkeyedDecodingContainer.swift
@@ -191,6 +191,13 @@ extension _CBORDecoder.UnkeyedContainer {
             _ = container.nestedContainers
 
             self.index = container.index
+            // Ensure that we're moving the index along for indefinite arrays so
+            // that we don't try and decode the break byte (0xff)
+            if format == 0x9f {
+                if self.data.suffix(from: self.index).count > 0 {
+                    self.index = self.index.advanced(by: 1)
+                }
+            }
             return container
         // Maps
         case 0xa0...0xbf:
@@ -198,6 +205,13 @@ extension _CBORDecoder.UnkeyedContainer {
             let _ = try container.nestedContainers() // FIXME
 
             self.index = container.index
+            // Ensure that we're moving the index along for indefinite arrays so
+            // that we don't try and decode the break byte (0xff)
+            if format == 0xbf {
+                if self.data.suffix(from: self.index).count > 0 {
+                    self.index = self.index.advanced(by: 1)
+                }
+            }
             return container
         case 0xc0:
             throw DecodingError.dataCorruptedError(in: self, debugDescription: "Handling text-based date/time is not supported yet")

--- a/Tests/CBORCodableRoundtripTests.swift
+++ b/Tests/CBORCodableRoundtripTests.swift
@@ -275,6 +275,70 @@ class CBORCodableRoundtripTests: XCTestCase {
         XCTAssertEqual(decodedCBOROrder.status, order.status)
     }
 
+    func testStructWithArray() {
+        struct StructWithArray: Codable, Equatable {
+            let arr: [Int]
+        }
+
+        let arraysToTest = [[], [1], [2, 3]]
+
+        for arr in arraysToTest {
+            let structWithArray = StructWithArray(arr: arr)
+
+            let encoded = try! CodableCBOREncoder().encode(structWithArray)
+            let decoded = try! CodableCBORDecoder().decode(StructWithArray.self, from: encoded)
+
+            XCTAssertEqual(structWithArray, decoded)
+        }
+    }
+
+    func testMultiTypeStruct() {
+        struct MultiTypeStruct: Codable, Equatable {
+            let stringVal: String
+            let bytesVal: Data
+            let integer: Int
+            let booleanVal: Bool
+            let doubleVal: Double
+            let arrayVal: [Int]?
+        }
+
+        let arraysToTest: [[Int]?] = [[], nil]
+
+        for arr in arraysToTest {
+            let multiTypeStruct = MultiTypeStruct(
+                stringVal: "s",
+                bytesVal: Data(hex: "aabbcc")!,
+                integer: 4711,
+                booleanVal: true,
+                doubleVal: 3.14,
+                arrayVal: arr
+            )
+
+            let encoded = try! CodableCBOREncoder().encode(multiTypeStruct)
+            let decoded = try! CodableCBORDecoder().decode(MultiTypeStruct.self, from: encoded)
+
+            XCTAssertEqual(multiTypeStruct, decoded)
+        }
+
+        let hexToRoundtrip = [
+            // Definite map without an arrayVal key-value pair
+            "a56a626f6f6c65616e56616cf569737472696e6756616c63666f6f69646f75626c6556616cfb40091eb851eb851f67696e746567657219126768627974657356616c43aabbcc",
+
+            // Indefinite map without an arrayVal key-value pair
+            "bf6a626f6f6c65616e56616cf569737472696e6756616c63666f6f69646f75626c6556616cfb40091eb851eb851f67696e746567657219126768627974657356616c43aabbccff",
+
+            // Definite map with an arrayVal key-value pair
+            "a669737472696e6756616c63666f6f6a626f6f6c65616e56616cf567696e746567657219126769646f75626c6556616cfb40091eb851eb851f68627974657356616c43aabbcc68617272617956616c84010222191267",
+
+            // Indefinite map with an arrayVal key-value pair
+            "bf69737472696e6756616c63666f6f6a626f6f6c65616e56616cf567696e746567657219126769646f75626c6556616cfb40091eb851eb851f68627974657356616c43aabbcc68617272617956616c84010222191267ff"
+        ]
+
+        for hex in hexToRoundtrip {
+            let _ = try! CodableCBORDecoder().decode(MultiTypeStruct.self, from: Data(hex: hex)!)
+        }
+    }
+
     func testFoundationHeavyType() {
         struct FoundationLaden: Codable, Equatable {
             let date: Date

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension Data {
+    init?(hex: String) {
+        let len = hex.count / 2
+        var data = Data(capacity: len)
+        for i in 0..<len {
+            let j = hex.index(hex.startIndex, offsetBy: i*2)
+            let k = hex.index(j, offsetBy: 2)
+            let bytes = hex[j..<k]
+            if var num = UInt8(bytes, radix: 16) {
+                data.append(&num, count: 1)
+            } else {
+                return nil
+            }
+        }
+        self = data
+    }
+}
+
+extension Data {
+    var hex: String {
+        return reduce("") { $0 + String(format: "%02x", $1) }
+    }
+}

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -23,3 +23,17 @@ extension Data {
         return reduce("") { $0 + String(format: "%02x", $1) }
     }
 }
+
+extension StringProtocol {
+    var hexaData: Data { .init(hexa) }
+    var hexaBytes: [UInt8] { .init(hexa) }
+
+    private var hexa: UnfoldSequence<UInt8, Index> {
+        sequence(state: startIndex) { startIndex in
+            guard startIndex < self.endIndex else { return nil }
+            let endIndex = self.index(startIndex, offsetBy: 2, limitedBy: self.endIndex) ?? self.endIndex
+            defer { startIndex = endIndex }
+            return UInt8(self[startIndex..<endIndex], radix: 16)
+        }
+    }
+}


### PR DESCRIPTION
See the individual commits for more information about each fix.